### PR TITLE
Allow building without beeps and alsa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,12 +312,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
-name = "claxon"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,12 +790,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hound"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
-
-[[package]]
 name = "http"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,17 +997,6 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
-name = "lewton"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777b48df9aaab155475a83a7df3070395ea1ac6902f5cd062b8f2b028075c030"
-dependencies = [
- "byteorder",
- "ogg",
- "tinyvec",
-]
 
 [[package]]
 name = "libc"
@@ -1312,15 +1289,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f44155e7fb718d3cfddcf70690b2b51ac4412f347cd9e4fbe511abe9cd7b5f2"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "ogg"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6951b4e8bf21c8193da321bcce9c9dd2e13c858fe078bf9054a288b419ae5d6e"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -1624,10 +1592,7 @@ version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b1bb7b48ee48471f55da122c0044fcc7600cfcc85db88240b89cb832935e611"
 dependencies = [
- "claxon",
  "cpal",
- "hound",
- "lewton",
  "symphonia",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ license = "MIT"
 name = "gar"
 path = "src/main.rs"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["beep"]
+beep = ["rodio"]
 
 [dependencies]
 colored = "2.1.0"
@@ -29,5 +31,5 @@ prettytable-rs = "0.10.0"
 indicatif = "0.17.7"
 zip = "0.6.6"
 dirs = { version = "5.0.1", features = [] }
-rodio = "0.17.3"
+rodio = { version = "0.17.3", default-features = false, features = ["mp3"], optional = true }
 strsim = "0.11.0"

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,9 +1,12 @@
 use std::{env, fs};
-use std::io::{BufReader, Cursor, Read};
+use std::io::{Cursor, Read};
+#[cfg(feature = "rodio")]
+use std::io::BufReader;
 use zip::ZipArchive;
 use std::sync::Arc;
 use std::time::Duration;
 use indicatif::ProgressBar;
+#[cfg(feature = "rodio")]
 use rodio::{Decoder, OutputStream, Sink};
 use tokio::sync::Mutex;
 
@@ -81,6 +84,7 @@ pub(crate) fn install_zsh_autocompletion() -> Result<(), Box<dyn std::error::Err
     Ok(())
 }
 
+#[cfg(feature = "rodio")]
 pub(crate) fn beep(count: u8) {
     let (_stream, handle) = OutputStream::try_default().unwrap();
     let beep_mp3_data = include_bytes!("../beep.mp3").to_vec();
@@ -99,3 +103,6 @@ pub(crate) fn beep(count: u8) {
         }
     }
 }
+
+#[cfg(not(feature = "rodio"))]
+pub(crate) fn beep(_count: u8) {}


### PR DESCRIPTION
The beep requires alsa on Linux, and I would rather not install that, and also dont want beeps.